### PR TITLE
Corrected UniRecog.py

### DIFF
--- a/Python/UniRecog.py
+++ b/Python/UniRecog.py
@@ -84,7 +84,7 @@ class UniRecogTermination(UniMRCPAudioTermination):
             data = open(pcmfile, "rb").read()
             self.stream = UniMRCPStreamRxMemory(data, True, UniMRCPStreamRxMemory.SRM_NOTHING, True)
         elif streamType == ST_FILE:
-            self.stream = UniMRCPStreamRxFile(pcmfile, 0, SRM_NOTHING, True)
+            self.stream = UniMRCPStreamRxFile(pcmfile, 0, UniMRCPStreamRxMemory.SRM_NOTHING, True)
 
     def OnStreamOpenRx(self, enabled, payload_type, name, format, channels, freq):
         # Configure outgoing stream here


### PR DESCRIPTION
Hi, I confirmed the wrapper still works with unimrcp 1.7.0. 
I tested sample scripts UniSynth.py and UniRecog.py.
However there is a small error in UniRecog.py.
